### PR TITLE
Changing 'classic notebook' label to 'notebook' inorder to include JN7.0

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -20,8 +20,8 @@ function generateRegularUrl(hubUrl, repoUrl, branch, app, filepath) {
 }
 
 const AVAILABLE_APPS = {
-    classic: {
-        title: 'Classic Notebook',
+    notebook: {
+        title: 'Notebook',
         generateUrlPath: function (path) { return 'tree/' + path; },
     },
     retrolab: {


### PR DESCRIPTION
First attempt at tweaking the label to be inclusive of Jupyter Notebook 7.0 release. @yuvipanda - Please feel free to point me in the right direction if I had made any mistakes with this PR. Thanks in advance!