### PR TITLE
Fixing selectors for new GitHub UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+.DS_Store
+
+package-lock.json
+web-ext-artifacts/

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ npx webpack --mode=production
 npx web-ext build -s dist/
 ```
 
-This produces a `.xpi` file in `web-ext-artifacts/` you can use.
+This produces a `.zip` file in `web-ext-artifacts/` you can use.

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -130,9 +130,12 @@ function setup() {
         document.querySelector('.file-navigation > div.d-flex').prepend(root);
     } else if (document.getElementById('blob-path')) {
         // On a particular file, insert it after the name of the file
-        document.getElementById('blob-path').insertAdjacentElement('afterend', root)
+        document.getElementById('blob-path').insertAdjacentElement('afterend', root);
+    } else if (document.querySelector('[data-testid="breadcrumb-copy-path-button"]')) {
+         // On a particular file/directory, insert it after the name of the file (new GitHub UI)
+        document.querySelector('[data-testid="breadcrumb-copy-path-button"]').insertAdjacentElement('afterend', root);
     } else if (document.querySelector('.file-navigation > div.flex-auto')) {
-        // On root page of repo, insert this as first button, before 'Go To File'
+        // On root page of repo, insert this as first button, before 'Go To File' (old&new GitHub UI)
         document.querySelector('.file-navigation > div.flex-auto').insertAdjacentElement('afterend', root);
     } else {
         // Looks like we're not on a page with content


### PR DESCRIPTION
A single new selector takes care of both file and directory view in the new GitHub. I'm using data-testid which should hopefully be fairly stable (it's generally added to codebases for making more stable end-to-end tests).

Screenshots:

![Screenshot 2023-06-14 at 12 31 46 PM](https://github.com/yuvipanda/nbgitpuller-link-generator-webextension/assets/297042/296a6d88-9c30-4f2a-95c3-ae775df7646b)

![Screenshot 2023-06-14 at 12 31 52 PM](https://github.com/yuvipanda/nbgitpuller-link-generator-webextension/assets/297042/ef51a0f6-a40e-4e81-b4a6-c10c7e18f710)
